### PR TITLE
Allow for any type of response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 json.json
+cache


### PR DESCRIPTION
By making pretty print return the input argument when failed, any response like HTML can be compared

- **Added cache to gitigonore**
- **Allow for any type of response**
