### PR TITLE
Redo the JSON template to add more flexibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,33 +37,42 @@ The JSON configuration should be structured as follows:
 
 ```json
 {
-  "ignore_lines": [],
   "requests": [
     {
       "name": "Example comparison",
+      "ignore_lines": [],
       "left": {
         "method": "GET",
-        "url": "https://api.example.com/data",
+        "url": "http://localhost:5000/data",
+        "cached": false,
         "headers": {
-          "Authorization": "Bearer <token>",
           "Accept": "application/json"
+        },
+        "auth": {
+          "basic_auth": {
+            "username": "example",
+            "password": "example1234"
+          }
         },
         "query": {
           "limit": "10",
           "sort": "desc"
-        },
+        }
       },
       "right": {
         "method": "GET",
-        "url": "https://api.example.com/v2/data",
+        "ignore_lines": [],
+        "url": "http://localhost:5000/data",
+        "cached": false,
         "headers": {
-          "Authorization": "Bearer <token>",
           "Accept": "application/json"
         },
-        "query": {
-          "limit": "10",
-          "sort": "desc"
+        "auth": {
+          "token": "jhdsn3qe2w784yn0n3"
         },
+        "query": {
+          "sort": "desc"
+        }
       }
     }
   ]

--- a/README.md
+++ b/README.md
@@ -40,22 +40,30 @@ The JSON configuration should be structured as follows:
   "ignore_lines": [],
   "requests": [
     {
-      "name": "Comparison Name",
+      "name": "Example comparison",
       "left": {
-        "url": "https://example.com",
-        "ignore_lines": [],
-        "cached": true,
-        "user": "username",
-        "password": "password",
-        "token": "bearer_token"
+        "method": "GET",
+        "url": "https://api.example.com/data",
+        "headers": {
+          "Authorization": "Bearer <token>",
+          "Accept": "application/json"
+        },
+        "query": {
+          "limit": "10",
+          "sort": "desc"
+        },
       },
       "right": {
-        "url": "https://example.com",
-        "ignore_lines": [],
-        "cached": false,
-        "user": "username",
-        "password": "password",
-        "token": "bearer_token"
+        "method": "GET",
+        "url": "https://api.example.com/v2/data",
+        "headers": {
+          "Authorization": "Bearer <token>",
+          "Accept": "application/json"
+        },
+        "query": {
+          "limit": "10",
+          "sort": "desc"
+        },
       }
     }
   ]

--- a/src/args.rs
+++ b/src/args.rs
@@ -14,27 +14,29 @@ use crate::client::Config;
     long_about = "Takes multiple web links and compare their results between eachother"
 )]
 pub struct Args {
-    /// Path of the json file format to load for urls configurations. The configuration should be map of a list of requests, each request has name, and an object of left and righta list of objects each having left, and right.
-    /// each object will be formatted in this format
+    /// Path of the JSON file format to load for URLs configurations. The configuration consists of a map with a list of requests.
+    /// Each request has a mandatory `name` and an object specifying the HTTP request parameters.
     ///
-    ///+ {n}
-    ///+  "ignore_lines": [], An array of strings to be ignored if the line contains them, this ignore lines config is global for all requests{n}
-    ///+  "requests": [{n}
-    ///+    {{n}
-    ///+      "name":"", Mandatory name field, a string holding the name of the comparison{n}
-    ///+      "left": {{n}
-    ///+         "url": "https://example.com", Mandatory URL field {n}
-    ///+         "ignore_lines":[] Optional local ignore_lines{n}
-    ///+         "cached": boolean Optional to cache the response and reuse it instead of sending a request again{n}
-    ///+         "user": Optional string value if the call requires authentication{n}
-    ///+         "password": Optional string value if the call requires authentication{n}
-    ///+         "token": Optional token value, if the call requires a token bearer authentication{n}
-    ///+      },{n}
-    ///+      "right": {}, With the same fields and options as "left"{n}
-    ///+    }]{n}
-    ///+ }{n}
-    ///  Environmental variables can be used, either by providing them on the command level or by including them in a `.env` file. to use them inside the json wrap them in a ${}
-    ///  Example: if we have an environmental variable `HOST=https://google.com` and we use `"url": "${HOST}/query` when the program runs it will resolve to `"url": "https://google.com/query`
+    /// Each request object has this format:
+    ///
+    /// + {n}
+    /// +  "name": "",                      Mandatory name field, a string identifying the comparison
+    /// +  "method": "",                    HTTP method (GET, POST, etc.)
+    /// +  "url": "",                       Mandatory URL field
+    /// +  "headers": {},                   Optional map of header keys and values
+    /// +  "auth": {                        Optional map of authorization keys and values
+    /// +    "username": "",                username and (optional) password would be encoded using the basic authorization encoding.
+    /// +    "password": "",
+    /// +    "token": "",                   token will be passed as Bearer Token
+    /// +   },                              
+    /// +  "query": {},                     Optional map of query parameters
+    /// +  "body": {},                      Optional JSON body for POST, PUT, etc.
+    /// +  "timeout": 10,                   Optional timeout in seconds
+    /// +  "cached": false,                 Optional boolean to cache the response and reuse it instead of sending the request again
+    ///
+    /// Environmental variables can be used by wrapping them in `${}` within any string value inside the JSON config.
+    /// Example: if you have an environment variable `HOST=https://google.com`
+    /// and you use `"url": "${HOST}/query"`, when the program runs it will resolve to `"url": "https://google.com/query"`.
     pub path: PathBuf,
 
     /// Clear old cache for this json config

--- a/src/client/clients.rs
+++ b/src/client/clients.rs
@@ -35,7 +35,7 @@ pub trait RequestClient {
         }));
 
         if let Some(ref body) = part_request.body {
-            request = request.body(body.clone().as_str().context("Body content is invalid")?); // TODO: Fix this
+            request = request.body(body.clone().to_string());
         }
 
         let response = request

--- a/src/client/request.rs
+++ b/src/client/request.rs
@@ -1,4 +1,5 @@
 use serde::Deserialize;
+use std::collections::HashMap;
 use std::fmt::Display;
 
 #[derive(Deserialize)]
@@ -32,12 +33,38 @@ impl Display for RequestsConfig {
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct PartRequestConfig {
+    pub method: String,
     pub url: String,
+    pub cached: bool,
+
+    #[serde(default)]
+    pub auth: Option<RequestAuth>,
+
     #[serde(default)]
     pub ignore_lines: Vec<String>,
+
     #[serde(default)]
-    pub cached: bool,
-    pub user: Option<String>,
-    pub password: Option<String>,
+    pub headers: HashMap<String, String>,
+
+    #[serde(default)]
+    pub query: HashMap<String, String>,
+
+    #[serde(default)]
+    pub body: Option<serde_json::Value>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RequestAuth {
+    pub basic_auth: Option<BasicAuth>,
+
+    #[serde(default)]
     pub token: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BasicAuth {
+    pub username: String,
+    pub password: Option<String>,
 }


### PR DESCRIPTION
Allow POST requests
Allow to set custom headers
Authorization (tokens and basic)
HTTP Query parameters like ?limit=12 represented in JSON
Allow to send body inside the request (untested)
